### PR TITLE
chore: upgrade @mindconnect/@mindconnect-nodejs to 3.8.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "Jupiter Bakakeu"
   ],
   "dependencies": {
-    "@mindconnect/mindconnect-nodejs": "^3.3.0",
+    "@mindconnect/mindconnect-nodejs": "^3.8.0",
     "amqplib": "^0.5.3",
     "async": "^2.6.2",
     "backoff": "^2.5.0",


### PR DESCRIPTION
Hi Jupiter, the 3.3.0 is quite old :)